### PR TITLE
Fix bugs with Samsung devices

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -30,8 +30,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly'
-    implementation 'org.tensorflow:tensorflow-lite-gpu:0.0.0-nightly'
+    implementation 'org.tensorflow:tensorflow-lite:1.13.1'
 }
 
 apply plugin: 'com.github.dcendents.android-maven'

--- a/base/src/main/java/com/getbouncer/cardscan/base/ImageClassifier.java
+++ b/base/src/main/java/com/getbouncer/cardscan/base/ImageClassifier.java
@@ -32,7 +32,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.PriorityQueue;
 import org.tensorflow.lite.Interpreter;
-import org.tensorflow.lite.gpu.GpuDelegate;
 
 /**
  * Classifies images with Tensorflow Lite.
@@ -67,9 +66,6 @@ abstract class ImageClassifier {
     /** A ByteBuffer to hold image data, to be feed into Tensorflow Lite as inputs. */
     protected ByteBuffer imgData = null;
 
-
-    /** holds a gpu delegate */
-    GpuDelegate gpuDelegate = null;
 
     /** Initializes an {@code ImageClassifier}. */
     ImageClassifier(Context context) throws IOException {
@@ -106,14 +102,6 @@ abstract class ImageClassifier {
         }
     }
 
-    public void useGpu() {
-        if (gpuDelegate == null) {
-            gpuDelegate = new GpuDelegate();
-            tfliteOptions.addDelegate(gpuDelegate);
-            recreateInterpreter();
-        }
-    }
-
     public void useCPU() {
         tfliteOptions.setUseNNAPI(false);
         recreateInterpreter();
@@ -133,10 +121,6 @@ abstract class ImageClassifier {
     public void close() {
         tflite.close();
         tflite = null;
-        if (gpuDelegate != null) {
-            gpuDelegate.close();
-            gpuDelegate = null;
-        }
         tfliteModel = null;
     }
 

--- a/base/src/main/java/com/getbouncer/cardscan/base/Ocr.java
+++ b/base/src/main/java/com/getbouncer/cardscan/base/Ocr.java
@@ -2,6 +2,7 @@ package com.getbouncer.cardscan.base;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.util.Log;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -116,8 +117,9 @@ class Ocr {
             if (findFour == null) {
                 findFour = new FindFourModel(context);
                 try {
-                    findFour.useGpu();
+                    findFour.useNNAPI();
                 } catch (Exception e) {
+                    Log.e("Ocr", "findFour NNAPI exception", e);
                     findFour = new FindFourModel(context);
                     findFour.useCPU();
                 }
@@ -125,13 +127,23 @@ class Ocr {
 
             if (recognizedDigitsModel == null) {
                 recognizedDigitsModel = new RecognizedDigitsModel(context);
+                try {
+                    recognizedDigitsModel.useNNAPI();
+                } catch (Exception e) {
+                    Log.e("Ocr", "recognizeDigits NNAPI exception", e);
+                    recognizedDigitsModel = new RecognizedDigitsModel(context);
+                    recognizedDigitsModel.useCPU();
+                }
             }
 
             try {
                 return runModel(image);
             } catch (Exception e) {
+                Log.e("Ocr", "runModel exception", e);
                 findFour = new FindFourModel(context);
                 findFour.useCPU();
+                recognizedDigitsModel = new RecognizedDigitsModel(context);
+                recognizedDigitsModel.useCPU();
                 return runModel(image);
             }
 

--- a/base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -146,7 +146,7 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
                 setCameraDisplayOrientation(this, Camera.CameraInfo.CAMERA_FACING_BACK,
                         mCamera);
                 // Create our Preview view and set it as the content of our activity.
-                CameraPreview cameraPreview = new CameraPreview(this);
+                CameraPreview cameraPreview = new CameraPreview(this, this);
                 FrameLayout preview = findViewById(mTextureId);
                 preview.addView(cameraPreview);
                 mCamera.setPreviewCallback(this);
@@ -433,9 +433,12 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
     /** A basic Camera preview class */
     public class CameraPreview extends SurfaceView implements Camera.AutoFocusCallback, SurfaceHolder.Callback {
         private SurfaceHolder mHolder;
+        private Camera.PreviewCallback mPreviewCallback;
 
-        public CameraPreview(Context context) {
+        public CameraPreview(Context context, Camera.PreviewCallback previewCallback) {
             super(context);
+
+            mPreviewCallback = previewCallback;
 
             // Install a SurfaceHolder.Callback so we get notified when the
             // underlying surface is created and destroyed.
@@ -496,6 +499,7 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
             // start preview with new settings
             try {
                 mCamera.setPreviewDisplay(mHolder);
+                mCamera.setPreviewCallback(mPreviewCallback);
                 mCamera.startPreview();
             } catch (Exception e){
                 Log.d("CameraCaptureActivity", "Error starting camera preview: " + e.getMessage());


### PR DESCRIPTION
There were two bugs with Samsung devices that this PR addresses:
* For old devices, the version of tensorflow-lite-gpu we were using had a bad dependency
* For the Samsung S7, the onPreviewFrame wasn't getting called

To fix these we removed the GPU version of tensorflow lite and instead use NNAPI and added an extra call for setting the previewFrame callback. Removing tensorflow lite hurts because it can use the GPU on any API 15 or higher device, whereas NNAPI only supports API 27, but given the stability of it this is the right trade off to make. We'll keep investigating and will test thoroughly before we merge this PR, but this is what it looks like thus far.