### PR TITLE
Use location in window instead of screen

### DIFF
--- a/base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -135,7 +135,7 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
         public void onGlobalLayout() {
             int[] xy = new int[2];
             View view = findViewById(cardRectangleId);
-            view.getLocationOnScreen(xy);
+            view.getLocationInWindow(xy);
 
             // convert from DP to pixels
             int radius = (int) (11 * Resources.getSystem().getDisplayMetrics().density);


### PR DESCRIPTION
There are some phone (e.g., Xiaomi redmi 7) that don't let full screen activities occupy a strip of screen at the top where the camera protrudes, thus if you get the coordinates of something relative to the screen it will be wrong. The fix is simple -- just get the location relative to the window.