### PR TITLE
Replace renderscript with gpuimage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /captures
 .externalNativeBuild
 langapiconfig.json
+*.cxx

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ We publish our library in the jcenter repository, so for most gradle configurati
 
 ```gradle
 dependencies {
-    implementation 'com.getbouncer:base:1.0.5113'
-    implementation 'com.getbouncer:cardscan:1.0.5113'
+    implementation 'com.getbouncer:cardscan-base:1.0.5114'
+    implementation 'com.getbouncer:cardscan:1.0.5114'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,16 +20,21 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    implementation project(':cardscan-base')
+    implementation project(":cardscan")
+
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.1.0'
+    implementation 'com.stripe:stripe-android:8.7.0'
+}
+
+dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'
-    implementation project(':cardscan-base')
-    implementation project(":cardscan")
-    implementation 'com.stripe:stripe-android:8.7.0'
 }
 
 // Ugg, who knows: https://github.com/facebook/flipper/issues/146

--- a/cardscan-base/build.gradle
+++ b/cardscan-base/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
 
-
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28
@@ -11,10 +10,12 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        renderscriptTargetApi 18
-        renderscriptSupportModeEnabled true
         buildConfigField "String", "CARDSCAN_VERSION", "\"$version\""
 
+    }
+
+    externalNativeBuild {
+        cmake { path "src/main/cpp/CMakeLists.txt" }
     }
 
     buildTypes {
@@ -31,11 +32,14 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.1.0'
+    implementation 'org.tensorflow:tensorflow-lite:1.15.0'
+}
+
+dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.1.0'
-    implementation 'org.tensorflow:tensorflow-lite:1.15.0'
 }
 
 apply plugin: 'com.github.dcendents.android-maven'
@@ -63,7 +67,7 @@ ext {
 
     licenseName = 'BSD 3-Clause'
     licenseUrl = 'http://opensource.org/licenses/BSD-3-Clause'
-    allLicenses = ["BSD 3-Clause"]
+    allLicenses = ["BSD 3-Clause", "Apache-2.0"]
 }
 
 

--- a/cardscan-base/src/main/cpp/CMakeLists.txt
+++ b/cardscan-base/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,46 @@
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html
+
+# Sets the minimum version of CMake required to build the native library.
+
+cmake_minimum_required(VERSION 3.4.1)
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+add_library( # Sets the name of the library.
+        yuv-decoder
+
+        # Sets the library as a shared library.
+        SHARED
+
+        # Provides a relative path to your source file(s).
+        yuv-decoder.c)
+
+# Searches for a specified prebuilt library and stores the path as a
+# variable. Because CMake includes system libraries in the search path by
+# default, you only need to specify the name of the public NDK library
+# you want to add. CMake verifies that the library exists before
+# completing its build.
+
+find_library( # Sets the name of the path variable.
+        log-lib
+
+        # Specifies the name of the NDK library that
+        # you want CMake to locate.
+        log)
+
+# Specifies libraries CMake should link to your target library. You
+# can link multiple libraries, such as libraries you define in this
+# build script, prebuilt third-party libraries, or system libraries.
+
+target_link_libraries( # Specifies the target library.
+        yuv-decoder
+
+        # Links the target library to the log library
+        # included in the NDK.
+        ${log-lib}
+        GLESv2
+        jnigraphics)

--- a/cardscan-base/src/main/cpp/yuv-decoder.c
+++ b/cardscan-base/src/main/cpp/yuv-decoder.c
@@ -1,0 +1,158 @@
+#include <jni.h>
+
+#include <android/bitmap.h>
+#include <GLES2/gl2.h>
+
+
+JNIEXPORT void JNICALL
+Java_com_getbouncer_cardscan_base_image_YUVDecoder_YUVtoRBGA(JNIEnv *env, jobject obj,
+                                                             jbyteArray yuv420sp,
+                                                             jint width, jint height,
+                                                             jintArray rgbOut) {
+    int sz;
+    int i;
+    int j;
+    int Y;
+    int Cr = 0;
+    int Cb = 0;
+    int pixPtr = 0;
+    int jDiv2 = 0;
+    int R = 0;
+    int G = 0;
+    int B = 0;
+    int cOff;
+    int w = width;
+    int h = height;
+    sz = w * h;
+
+    jint *rgbData = (jint *) ((*env)->GetPrimitiveArrayCritical(env, rgbOut, 0));
+    jbyte *yuv = (jbyte *) (*env)->GetPrimitiveArrayCritical(env, yuv420sp, 0);
+
+    for (j = 0; j < h; j++) {
+        pixPtr = j * w;
+        jDiv2 = j >> 1;
+        for (i = 0; i < w; i++) {
+            Y = yuv[pixPtr];
+            if (Y < 0) Y += 255;
+            if ((i & 0x1) != 1) {
+                cOff = sz + jDiv2 * w + (i >> 1) * 2;
+                Cb = yuv[cOff];
+                if (Cb < 0) Cb += 127; else Cb -= 128;
+                Cr = yuv[cOff + 1];
+                if (Cr < 0) Cr += 127; else Cr -= 128;
+            }
+
+            //ITU-R BT.601 conversion
+            //
+            //R = 1.164*(Y-16) + 2.018*(Cr-128);
+            //G = 1.164*(Y-16) - 0.813*(Cb-128) - 0.391*(Cr-128);
+            //B = 1.164*(Y-16) + 1.596*(Cb-128);
+            //
+            Y = Y + (Y >> 3) + (Y >> 5) + (Y >> 7);
+            R = Y + (Cr << 1) + (Cr >> 6);
+            if (R < 0) R = 0; else if (R > 255) R = 255;
+            G = Y - Cb + (Cb >> 3) + (Cb >> 4) - (Cr >> 1) + (Cr >> 3);
+            if (G < 0) G = 0; else if (G > 255) G = 255;
+            B = Y + Cb + (Cb >> 1) + (Cb >> 4) + (Cb >> 5);
+            if (B < 0) B = 0; else if (B > 255) B = 255;
+            rgbData[pixPtr++] = 0xff000000 + (R << 16) + (G << 8) + B;
+        }
+    }
+
+    (*env)->ReleasePrimitiveArrayCritical(env, rgbOut, rgbData, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, yuv420sp, yuv, 0);
+}
+
+JNIEXPORT void JNICALL
+Java_com_getbouncer_cardscan_base_image_YUVDecoder_YUVtoARBG(JNIEnv *env, jobject obj,
+                                                             jbyteArray yuv420sp,
+                                                             jint width, jint height,
+                                                             jintArray rgbOut) {
+    int sz;
+    int i;
+    int j;
+    int Y;
+    int Cr = 0;
+    int Cb = 0;
+    int pixPtr = 0;
+    int jDiv2 = 0;
+    int R = 0;
+    int G = 0;
+    int B = 0;
+    int cOff;
+    int w = width;
+    int h = height;
+    sz = w * h;
+
+    jint *rgbData = (jint *) ((*env)->GetPrimitiveArrayCritical(env, rgbOut, 0));
+    jbyte *yuv = (jbyte *) (*env)->GetPrimitiveArrayCritical(env, yuv420sp, 0);
+
+    for (j = 0; j < h; j++) {
+        pixPtr = j * w;
+        jDiv2 = j >> 1;
+        for (i = 0; i < w; i++) {
+            Y = yuv[pixPtr];
+            if (Y < 0) Y += 255;
+            if ((i & 0x1) != 1) {
+                cOff = sz + jDiv2 * w + (i >> 1) * 2;
+                Cb = yuv[cOff];
+                if (Cb < 0) Cb += 127; else Cb -= 128;
+                Cr = yuv[cOff + 1];
+                if (Cr < 0) Cr += 127; else Cr -= 128;
+            }
+
+            //ITU-R BT.601 conversion
+            //
+            //R = 1.164*(Y-16) + 2.018*(Cr-128);
+            //G = 1.164*(Y-16) - 0.813*(Cb-128) - 0.391*(Cr-128);
+            //B = 1.164*(Y-16) + 1.596*(Cb-128);
+            //
+            Y = Y + (Y >> 3) + (Y >> 5) + (Y >> 7);
+            R = Y + (Cr << 1) + (Cr >> 6);
+            if (R < 0) R = 0; else if (R > 255) R = 255;
+            G = Y - Cb + (Cb >> 3) + (Cb >> 4) - (Cr >> 1) + (Cr >> 3);
+            if (G < 0) G = 0; else if (G > 255) G = 255;
+            B = Y + Cb + (Cb >> 1) + (Cb >> 4) + (Cb >> 5);
+            if (B < 0) B = 0; else if (B > 255) B = 255;
+            rgbData[pixPtr++] = 0xff000000 + (B << 16) + (G << 8) + R;
+        }
+    }
+
+    (*env)->ReleasePrimitiveArrayCritical(env, rgbOut, rgbData, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, yuv420sp, yuv, 0);
+}
+
+
+JNIEXPORT void JNICALL
+Java_com_getbouncer_cardscan_base_image_YUVDecoder_transposeBitmap(JNIEnv *jenv, jclass thiz,
+                                                                   jobject src) {
+    unsigned char *srcByteBuffer;
+    int result = 0;
+    int i, j;
+    AndroidBitmapInfo srcInfo;
+
+    result = AndroidBitmap_getInfo(jenv, src, &srcInfo);
+    if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+        return;
+    }
+
+    result = AndroidBitmap_lockPixels(jenv, src, (void **) &srcByteBuffer);
+    if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+        return;
+    }
+
+    int width = srcInfo.width;
+    int height = srcInfo.height;
+    glReadPixels(0, 0, srcInfo.width, srcInfo.height, GL_RGBA, GL_UNSIGNED_BYTE, srcByteBuffer);
+
+    int *pIntBuffer = (int *) srcByteBuffer;
+
+    for (i = 0; i < height / 2; i++) {
+        for (j = 0; j < width; j++) {
+            int temp = pIntBuffer[(height - i - 1) * width + j];
+            pIntBuffer[(height - i - 1) * width + j] = pIntBuffer[i * width + j];
+            pIntBuffer[i * width + j] = temp;
+        }
+    }
+    AndroidBitmap_unlockPixels(jenv, src);
+}

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/image/YUVDecoder.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/image/YUVDecoder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 CyberAgent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file was modified from https://github.com/cats-oss/android-gpuimage/blob/cc421fd1fc9f0a1bc56396066b942724e3b8d9ba/library/src/main/java/jp/co/cyberagent/android/gpuimage/GPUImageNativeLibrary.java
+ */
+
+package com.getbouncer.cardscan.base.image;
+
+import android.graphics.Bitmap;
+
+public class YUVDecoder {
+    static {
+        System.loadLibrary("yuv-decoder");
+    }
+
+    /**
+     * Convert a YUV nv21 image byte array to an RGBA image byte array
+     * @param yuv YUV nv21 image data
+     * @param width width of the source image
+     * @param height height of the source image
+     * @param out RGBA image data
+     */
+    public static native void YUVtoRBGA(byte[] yuv, int width, int height, int[] out);
+
+    /**
+     * Convert a YUV nv21 image byte array to an ARGB image byte array
+     * @param yuv YUV nv21 image data
+     * @param width width of the source image
+     * @param height height of the source image
+     * @param out RGBA image data
+     */
+    public static native void YUVtoARBG(byte[] yuv, int width, int height, int[] out);
+
+    /**
+     * Transpose the height and width of a bitmap
+     * @param srcBitmap Bitmap to transpose
+     */
+    public static native void transposeBitmap(Bitmap srcBitmap);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-version=1.0.5113
+version=1.0.5114


### PR DESCRIPTION
Remove the renderscript library (1.5Mb per arch) and replace it with parts of gpuimage native image processing. This library shouldn't change with much frequency, so we should be safe to include it as a fork of GPUImage.