### PR TITLE
Include androidx test espresso in proguard rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-	maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'

--- a/cardscan-base/proguard-rules.pro
+++ b/cardscan-base/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class androidx.test.espresso.* { ; }


### PR DESCRIPTION
https://trello.com/c/TL1e5rg5/101-include-r8-exceptions-in-the-sdk