### PR TITLE
Fix camera resolution selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ We publish our library in the jcenter repository, so for most gradle configurati
 
 ```gradle
 dependencies {
-    implementation 'com.getbouncer:cardscan-base:1.0.5124'
-    implementation 'com.getbouncer:cardscan:1.0.5124'
+    implementation 'com.getbouncer:cardscan-base:1.0.5125'
+    implementation 'com.getbouncer:cardscan:1.0.5125'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 4015
-        versionName "1.0.5124"
+        versionName "1.0.5125"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/CreditCardUtils.kt
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/CreditCardUtils.kt
@@ -1,3 +1,27 @@
+/*
+The MIT License
+
+Copyright (c) 2011- Stripe, Inc. (https://stripe.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 package com.getbouncer.cardscan.base
 
 import androidx.annotation.DrawableRes

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/MachineLearningThread.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/MachineLearningThread.java
@@ -131,6 +131,7 @@ class MachineLearningThread implements Runnable {
     }
 
     synchronized void post(Bitmap bitmap, OnScanListener scanListener, Context context) {
+        Log.d("BOUNCER", "post1 processing image size " + bitmap.getWidth() + "x" + bitmap.getHeight());
         RunArguments args = new RunArguments(bitmap, scanListener, context);
         queue.push(args);
         notify();
@@ -138,6 +139,7 @@ class MachineLearningThread implements Runnable {
 
     synchronized void post(byte[] bytes, int width, int height, int format, int sensorOrientation,
                            OnScanListener scanListener, Context context, float roiCenterYRatio) {
+        Log.d("BOUNCER", "post2 processing image size " + width + "x" + height + " rotation=" + sensorOrientation);
         RunArguments args = new RunArguments(bytes, width, height, format, sensorOrientation,
                 scanListener, context, roiCenterYRatio);
         queue.push(args);
@@ -146,6 +148,7 @@ class MachineLearningThread implements Runnable {
 
     synchronized void post(Bitmap bitmap, OnObjectListener objectListener, Context context,
                            File objectDetectFile) {
+        Log.d("BOUNCER", "post3 processing image size " + bitmap.getWidth() + "x" + bitmap.getHeight());
         RunArguments args = new RunArguments(bitmap, objectListener, context, objectDetectFile);
         queue.push(args);
         notify();
@@ -154,6 +157,7 @@ class MachineLearningThread implements Runnable {
     synchronized void post(byte[] bytes, int width, int height, int format, int sensorOrientation,
                            OnObjectListener objectListener, Context context, float roiCenterYRatio,
                            File objectDetectFile) {
+        Log.d("BOUNCER", "post4 processing image size " + width + "x" + height);
         RunArguments args = new RunArguments(bytes, width, height, format, sensorOrientation,
                 objectListener, context, roiCenterYRatio, objectDetectFile);
         queue.push(args);

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/MachineLearningThread.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/MachineLearningThread.java
@@ -131,7 +131,6 @@ class MachineLearningThread implements Runnable {
     }
 
     synchronized void post(Bitmap bitmap, OnScanListener scanListener, Context context) {
-        Log.d("BOUNCER", "post1 processing image size " + bitmap.getWidth() + "x" + bitmap.getHeight());
         RunArguments args = new RunArguments(bitmap, scanListener, context);
         queue.push(args);
         notify();
@@ -139,7 +138,6 @@ class MachineLearningThread implements Runnable {
 
     synchronized void post(byte[] bytes, int width, int height, int format, int sensorOrientation,
                            OnScanListener scanListener, Context context, float roiCenterYRatio) {
-        Log.d("BOUNCER", "post2 processing image size " + width + "x" + height + " rotation=" + sensorOrientation);
         RunArguments args = new RunArguments(bytes, width, height, format, sensorOrientation,
                 scanListener, context, roiCenterYRatio);
         queue.push(args);
@@ -148,7 +146,6 @@ class MachineLearningThread implements Runnable {
 
     synchronized void post(Bitmap bitmap, OnObjectListener objectListener, Context context,
                            File objectDetectFile) {
-        Log.d("BOUNCER", "post3 processing image size " + bitmap.getWidth() + "x" + bitmap.getHeight());
         RunArguments args = new RunArguments(bitmap, objectListener, context, objectDetectFile);
         queue.push(args);
         notify();
@@ -157,7 +154,6 @@ class MachineLearningThread implements Runnable {
     synchronized void post(byte[] bytes, int width, int height, int format, int sensorOrientation,
                            OnObjectListener objectListener, Context context, float roiCenterYRatio,
                            File objectDetectFile) {
-        Log.d("BOUNCER", "post4 processing image size " + width + "x" + height);
         RunArguments args = new RunArguments(bytes, width, height, format, sensorOrientation,
                 objectListener, context, roiCenterYRatio, objectDetectFile);
         queue.push(args);

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -403,38 +403,38 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
     }
 
     public void orientationChanged(int orientation) {
-        if (orientation == OrientationEventListener.ORIENTATION_UNKNOWN) return;
-        android.hardware.Camera.CameraInfo info =
-                new android.hardware.Camera.CameraInfo();
-        android.hardware.Camera.getCameraInfo(Camera.CameraInfo.CAMERA_FACING_BACK, info);
-        orientation = (orientation + 45) / 90 * 90;
-        int rotation = 0;
-        if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-            rotation = (info.orientation - orientation + 360) % 360;
-        } else {  // back-facing camera
-            rotation = (info.orientation + orientation) % 360;
-        }
-
-        if (mCamera != null) {
-            try {
-                Camera.Parameters params = mCamera.getParameters();
-                params.setRotation(rotation);
-                setCameraParameters(mCamera, params);
-            } catch (Exception | Error e) {
-                // This gets called often so we can just swallow it and wait for the next one
-                e.printStackTrace();
-            }
-        }
+//        if (orientation == OrientationEventListener.ORIENTATION_UNKNOWN) return;
+//        android.hardware.Camera.CameraInfo info =
+//                new android.hardware.Camera.CameraInfo();
+//        android.hardware.Camera.getCameraInfo(Camera.CameraInfo.CAMERA_FACING_BACK, info);
+//        orientation = (orientation + 45) / 90 * 90;
+//        int rotation = 0;
+//        if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+//            rotation = (info.orientation - orientation + 360) % 360;
+//        } else {  // back-facing camera
+//            rotation = (info.orientation + orientation) % 360;
+//        }
+//
+//        if (mCamera != null) {
+//            try {
+//                Camera.Parameters params = mCamera.getParameters();
+//                params.setRotation(rotation);
+//                setCameraParameters(mCamera, params);
+//            } catch (Exception | Error e) {
+//                // This gets called often so we can just swallow it and wait for the next one
+//                e.printStackTrace();
+//            }
+//        }
     }
 
     public void setCameraDisplayOrientation(Activity activity,
                                             int cameraId, android.hardware.Camera camera) {
-        android.hardware.Camera.CameraInfo info =
-                new android.hardware.Camera.CameraInfo();
-        android.hardware.Camera.getCameraInfo(cameraId, info);
-        int rotation = activity.getWindowManager().getDefaultDisplay()
-                .getRotation();
+        Camera.CameraInfo info = new Camera.CameraInfo();
+        Camera.getCameraInfo(cameraId, info);
+
+        int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
         int degrees = 0;
+
         switch (rotation) {
             case Surface.ROTATION_0: degrees = 0; break;
             case Surface.ROTATION_90: degrees = 90; break;
@@ -445,10 +445,11 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
         int result;
         if (info.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
             result = (info.orientation + degrees) % 360;
-            result = (360 - result) % 360;  // compensate the mirror
+            result = (360 - result) % 360;  // compensate for the mirror
         } else {  // back-facing
             result = (info.orientation - degrees + 360) % 360;
         }
+
         camera.setDisplayOrientation(result);
         mRotation = result;
     }
@@ -723,8 +724,6 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
             // underlying surface is created and destroyed.
             mHolder = getHolder();
             mHolder.addCallback(this);
-            // deprecated setting, but required on Android versions prior to 3.0
-            mHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
 
             Camera.Parameters params = mCamera.getParameters();
             List<String> focusModes = params.getSupportedFocusModes();
@@ -750,6 +749,7 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
             try {
                 mCamera.setPreviewDisplay(holder);
                 mCamera.startPreview();
+//                mCamera.setDisplayOrientation(90);
             } catch (IOException e) {
                 Log.d("CameraCaptureActivity", "Error setting camera preview: " + e.getMessage());
             }

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -267,14 +267,15 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
             }
         }
 
-        // Find something that is close to our target height but still bigger
+        // Find the closest ratio that is still taller than our target height
         if (optimalSize == null) {
-            double minDiff = Double.MAX_VALUE;
+            double minDiffRatio = Double.MAX_VALUE;
             for (Camera.Size size : sizes) {
                 double ratio = (double) size.width / size.height;
-                if (Math.abs(size.height - h) < minDiff && size.height >= h) {
+                double ratioDiff = Math.abs(ratio - targetRatio);
+                if (size.height >= h && ratioDiff <= minDiffRatio) {
                     optimalSize = size;
-                    minDiff = Math.abs(size.height - h);
+                    minDiffRatio = ratioDiff;
                 }
             }
         }

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -212,10 +212,11 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
         parameters.setPreviewFormat(format);
 
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+        getWindowManager().getDefaultDisplay().getRealMetrics(displayMetrics);
 
         int displayWidth = Math.max(displayMetrics.heightPixels, displayMetrics.widthPixels);
         int displayHeight = Math.min(displayMetrics.heightPixels, displayMetrics.widthPixels);
+        Log.d("BOUNCER", "setCameraPreviewFrame display metrics reports " + displayWidth + "x" + displayHeight);
 
         int height = MIN_IMAGE_EDGE;
         int width = displayWidth * height / displayHeight;

--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/ScanBaseActivity.java
@@ -259,7 +259,7 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
 
     // https://stackoverflow.com/a/17804792
     private @Nullable Camera.Size getOptimalPreviewSize(List<Camera.Size> sizes, int w, int h) {
-        final double ASPECT_TOLERANCE = 0.1;
+        final double ASPECT_TOLERANCE = 0.2;
         double targetRatio = (double) w / h;
         Log.d("BOUNCER", "getOptimalPreviewSize looking for camera preview " + w + "x" + h + " ratio=" + targetRatio);
 
@@ -274,7 +274,10 @@ public abstract class ScanBaseActivity extends Activity implements Camera.Previe
         // height
         for (Camera.Size size : sizes) {
             double ratio = (double) size.width / size.height;
-            if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE) continue;
+            if (Math.abs(ratio - targetRatio) > ASPECT_TOLERANCE) {
+                Log.d("BOUNCER", "getOptimalPreviewSize ignoring size " + size.width + "x" + size.height + " ratio=" + ratio + " because out of tolerance");
+                continue;
+            }
             if (size.height >= h) {
                 Log.d("BOUNCER", "getOptimalPreviewSize Considering preview size " + size.width + "x" + size.height + " ratio=" + ratio);
                 optimalSize = size;

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-version=1.0.5124
+version=1.0.5125


### PR DESCRIPTION
The camera always reports resolutions in landscape mode, regardless of the actual orientation of the device. Our original resolution selection was assuming that reported values changed based on device rotation.

Additionally, we were incorrectly calculating screen size, and our aspect ratio tolerance was too tight, causing us to frequently select 4:3 preview aspect ratios instead of 16:9.

https://trello.com/c/O0pRXemo/129-fix-camera-ratio-selection-for-tally