### PR TITLE
Fix hanging resource downloader

### DIFF
--- a/cardscan-base/src/main/java/com/getbouncer/cardscan/base/Api.java
+++ b/cardscan-base/src/main/java/com/getbouncer/cardscan/base/Api.java
@@ -67,6 +67,7 @@ public class Api {
             }
         } while (data != null);
 
+        in.close();
         return responseBody.toString();
     }
 


### PR DESCRIPTION
```
E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
    java.lang.Throwable: Explicit termination method 'end' not called
        at dalvik.system.CloseGuard.open(CloseGuard.java:223)
        at java.util.zip.Inflater.<init>(Inflater.java:106)
        at com.android.okhttp.okio.GzipSource.<init>(GzipSource.java:62)
        at com.android.okhttp.internal.http.HttpEngine.unzip(HttpEngine.java:473)
        at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:648)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:471)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getInputStream(HttpURLConnectionImpl.java:244)
        at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getInputStream(DelegatingHttpsURLConnection.java:210)
        at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getInputStream(Unknown Source:0)
        at com.getbouncer.cardscan.base.Api.downloadString(Api.java:59)
        at com.getbouncer.cardscan.base.Api.makeApiCallPostImplementation(Api.java:102)
        at com.getbouncer.cardscan.base.Api.access$000(Api.java:18)
        at com.getbouncer.cardscan.base.Api$1.run(Api.java:77)
        at java.lang.Thread.run(Thread.java:764)
```