### PR TITLE
Fix a camera crash on revvl2 devices

### DIFF
--- a/scan-camera/src/main/java/com/getbouncer/scan/camera/camera1/Camera1Adapter.kt
+++ b/scan-camera/src/main/java/com/getbouncer/scan/camera/camera1/Camera1Adapter.kt
@@ -26,7 +26,6 @@ import com.getbouncer.scan.camera.rotate
 import com.getbouncer.scan.camera.scale
 import com.getbouncer.scan.camera.toBitmap
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -39,6 +38,7 @@ import java.util.Random
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 private const val ASPECT_TOLERANCE = 0.2
 
@@ -109,18 +109,22 @@ class Camera1Adapter(
         }
     }
 
-    @ExperimentalCoroutinesApi
-    override fun onPreviewFrame(bytes: ByteArray, camera: Camera) {
+    override fun onPreviewFrame(bytes: ByteArray?, camera: Camera) {
         val imageWidth = camera.parameters.previewSize.width
         val imageHeight = camera.parameters.previewSize.height
         val scale = max(
             minimumResolution.width.toFloat() / imageWidth,
             minimumResolution.height.toFloat() / imageHeight
         )
-        val bitmap = bytes.nv21ToYuv(imageWidth, imageHeight).toBitmap().scale(scale).rotate(mRotation.toFloat())
-        camera.addCallbackBuffer(bytes)
 
-        sendImageToStream(bitmap)
+        if (bytes != null) {
+            val bitmap = bytes.nv21ToYuv(imageWidth, imageHeight).toBitmap().scale(scale).rotate(mRotation.toFloat())
+            camera.addCallbackBuffer(bytes)
+
+            sendImageToStream(bitmap)
+        } else {
+            camera.addCallbackBuffer(ByteArray((imageWidth * imageHeight * 1.5).roundToInt()))
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)


### PR DESCRIPTION
As reported by customer:

```
java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter bytes
    at com.getbouncer.scan.camera.camera1.Camera1Adapter.onPreviewFrame
    at android.hardware.Camera$EventHandler.handleMessage(Camera.java:1165)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:164)
    at android.app.ActivityThread.main(ActivityThread.java:6550)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:857)
```

from device

```
Manufacturer	TCL
Model	REVVL 2 (OPM1.171019.011)
Model Id	OPM1.171019.011
OS Version	8.1.0(Android O)
OS Rooted  NO
```