### PR TITLE
Tune the name & expiry extraction analyzers

### DIFF
--- a/scan-framework/src/main/java/com/getbouncer/scan/framework/time/Clock.kt
+++ b/scan-framework/src/main/java/com/getbouncer/scan/framework/time/Clock.kt
@@ -1,5 +1,7 @@
 package com.getbouncer.scan.framework.time
 
+import androidx.annotation.CheckResult
+
 object Clock {
     fun markNow(): ClockMark = PreciseClockMark(System.nanoTime())
 }
@@ -71,21 +73,10 @@ private class PreciseClockMark(private val originMark: Long) : ClockMark {
  *
  * TODO: use contracts when they are no longer experimental
  */
-inline fun <T> measureTimeWithResult(block: () -> T): Pair<Duration, T> {
+@CheckResult
+inline fun <T> measureTime(block: () -> T): Pair<Duration, T> {
     // contract { callsInPlace(block, EXACTLY_ONCE) }
     val mark = Clock.markNow()
     val result = block()
     return mark.elapsedSince() to result
-}
-
-/**
- * Measure the amount of time a process takes.
- *
- * TODO: use contracts when they are no longer experimental
- */
-inline fun measureTime(block: () -> Unit): Duration {
-    // contract { callsInPlace(block, EXACTLY_ONCE) }
-    val mark = Clock.markNow()
-    block()
-    return mark.elapsedSince()
 }

--- a/scan-framework/src/main/java/com/getbouncer/scan/framework/time/Timer.kt
+++ b/scan-framework/src/main/java/com/getbouncer/scan/framework/time/Timer.kt
@@ -57,7 +57,7 @@ private class LoggingTimer(
     // TODO: use contracts when they are no longer experimental
     override suspend fun <T> measureSuspend(taskName: String?, task: suspend () -> T): T {
         // contract { callsInPlace(task, EXACTLY_ONCE) }
-        val (duration, result) = measureTimeWithResult { task() }
+        val (duration, result) = measureTime { task() }
 
         executionCount++
         executionTotalDuration += duration

--- a/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/AlphabetDetect.kt
+++ b/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/AlphabetDetect.kt
@@ -68,7 +68,7 @@ class AlphabetDetect private constructor(interpreter: Interpreter) :
     ) : TFLAnalyzerFactory<AlphabetDetect>(context, fetchedModel) {
         companion object {
             private const val USE_GPU = false
-            private const val DEFAULT_THREADS = 3
+            private const val DEFAULT_THREADS = 1
         }
 
         override val tfOptions: Interpreter.Options = Interpreter

--- a/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/ExpiryDetect.kt
+++ b/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/ExpiryDetect.kt
@@ -127,7 +127,7 @@ class ExpiryDetect private constructor(interpreter: Interpreter) :
     ) : TFLAnalyzerFactory<ExpiryDetect>(context, fetchedModel) {
         companion object {
             private const val USE_GPU = false
-            private const val DEFAULT_THREADS = 3
+            private const val DEFAULT_THREADS = 1
         }
 
         override val tfOptions: Interpreter.Options = Interpreter

--- a/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/TextDetect.kt
+++ b/scan-payment/src/main/java/com/getbouncer/scan/payment/ml/TextDetect.kt
@@ -380,7 +380,7 @@ class TextDetect private constructor(interpreter: Interpreter) :
     ) : TFLAnalyzerFactory<TextDetect>(context, fetchedModel) {
         companion object {
             private const val USE_GPU = false
-            private const val DEFAULT_THREADS = 3
+            private const val DEFAULT_THREADS = 1
         }
 
         override val tfOptions: Interpreter.Options = Interpreter


### PR DESCRIPTION
Noticeable improvement across both low & high end devices. This reduces the number of threads used by ML models that run in parallel.