### PR TITLE
Fix crash on fade animations when minifying resources

### DIFF
--- a/cardscan-demo/src/main/java/com/getbouncer/cardscan/demo/SingleActivityDemo.java
+++ b/cardscan-demo/src/main/java/com/getbouncer/cardscan/demo/SingleActivityDemo.java
@@ -446,7 +446,7 @@ public class SingleActivityDemo extends AppCompatActivity implements CameraError
                     final String pan = state.getMostLikelyPan();
                     if (pan != null) {
                         cardPanTextView.setText(PanFormatterKt.formatPan(pan));
-                        ViewExtensionsKt.fadeIn(cardPanTextView, null);
+                        ViewExtensionsKt.show(cardPanTextView);
                     }
                     setStateFound();
 
@@ -457,7 +457,7 @@ public class SingleActivityDemo extends AppCompatActivity implements CameraError
                     final String pan = state.getMostLikelyPan();
                     if (pan != null) {
                         cardPanTextView.setText(PanFormatterKt.formatPan(pan));
-                        ViewExtensionsKt.fadeIn(cardPanTextView, null);
+                        ViewExtensionsKt.show(cardPanTextView);
                     }
 
                     setStateFound();
@@ -469,7 +469,7 @@ public class SingleActivityDemo extends AppCompatActivity implements CameraError
                     final String pan = state.getPan();
                     if (pan != null) {
                         cardPanTextView.setText(PanFormatterKt.formatPan(pan));
-                        ViewExtensionsKt.fadeIn(cardPanTextView, null);
+                        ViewExtensionsKt.show(cardPanTextView);
                     }
 
                     setStateFound();
@@ -540,7 +540,7 @@ public class SingleActivityDemo extends AppCompatActivity implements CameraError
     private void setStateCorrect() {
         if (scanState == State.CORRECT) return;
         ViewExtensionsKt.startAnimation(viewFinderBorder, R.drawable.bouncer_card_border_correct);
-        ViewExtensionsKt.fadeIn(processingOverlay, null);
+        ViewExtensionsKt.show(processingOverlay);
         scanState = State.CORRECT;
     }
 }

--- a/cardscan-ui-local/src/main/java/com/getbouncer/cardscan/ui/local/CardScanBaseActivity.kt
+++ b/cardscan-ui-local/src/main/java/com/getbouncer/cardscan/ui/local/CardScanBaseActivity.kt
@@ -18,7 +18,6 @@ import com.getbouncer.scan.payment.ml.ssd.DetectionBox
 import com.getbouncer.scan.ui.DebugDetectionBox
 import com.getbouncer.scan.ui.ScanResultListener
 import com.getbouncer.scan.ui.SimpleScanActivity
-import com.getbouncer.scan.ui.util.fadeIn
 import com.getbouncer.scan.ui.util.getColorByRes
 import com.getbouncer.scan.ui.util.setTextSizeByRes
 import com.getbouncer.scan.ui.util.setVisible
@@ -159,7 +158,7 @@ abstract class CardScanBaseActivity :
             }
             if (mostLikelyPan?.isNotEmpty() == true) {
                 cardNumberTextView.text = formatPan(mostLikelyPan)
-                cardNumberTextView.fadeIn()
+                cardNumberTextView.show()
             }
         }
 

--- a/cardscan-ui/src/main/java/com/getbouncer/cardscan/ui/CardScanActivity.kt
+++ b/cardscan-ui/src/main/java/com/getbouncer/cardscan/ui/CardScanActivity.kt
@@ -27,11 +27,11 @@ import com.getbouncer.scan.payment.card.getCardIssuer
 import com.getbouncer.scan.payment.card.isValidExpiry
 import com.getbouncer.scan.payment.ml.ssd.cropImageForObjectDetect
 import com.getbouncer.scan.ui.util.asRect
-import com.getbouncer.scan.ui.util.fadeIn
 import com.getbouncer.scan.ui.util.getColorByRes
 import com.getbouncer.scan.ui.util.hide
 import com.getbouncer.scan.ui.util.setTextSizeByRes
 import com.getbouncer.scan.ui.util.setVisible
+import com.getbouncer.scan.ui.util.show
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -380,9 +380,9 @@ open class CardScanActivity :
                 processingTextView.hide()
             }
             is ScanState.Correct -> {
-                processingOverlayView.fadeIn()
-                processingSpinnerView.fadeIn()
-                processingTextView.fadeIn()
+                processingOverlayView.show()
+                processingSpinnerView.show()
+                processingTextView.show()
             }
         }
     }

--- a/cardscan-ui/src/main/java/com/getbouncer/cardscan/ui/CardScanBaseActivity.kt
+++ b/cardscan-ui/src/main/java/com/getbouncer/cardscan/ui/CardScanBaseActivity.kt
@@ -18,7 +18,6 @@ import com.getbouncer.scan.payment.ml.ssd.DetectionBox
 import com.getbouncer.scan.ui.DebugDetectionBox
 import com.getbouncer.scan.ui.ScanResultListener
 import com.getbouncer.scan.ui.SimpleScanActivity
-import com.getbouncer.scan.ui.util.fadeIn
 import com.getbouncer.scan.ui.util.getColorByRes
 import com.getbouncer.scan.ui.util.setTextSizeByRes
 import com.getbouncer.scan.ui.util.setVisible
@@ -170,7 +169,7 @@ abstract class CardScanBaseActivity :
             }
             if (mostLikelyPan?.isNotEmpty() == true) {
                 cardNumberTextView.text = formatPan(mostLikelyPan)
-                cardNumberTextView.fadeIn()
+                cardNumberTextView.show()
             }
         }
 

--- a/scan-ui/src/main/java/com/getbouncer/scan/ui/SimpleScanActivity.kt
+++ b/scan-ui/src/main/java/com/getbouncer/scan/ui/SimpleScanActivity.kt
@@ -19,8 +19,6 @@ import com.getbouncer.scan.framework.TrackedImage
 import com.getbouncer.scan.framework.util.getSdkVersion
 import com.getbouncer.scan.ui.util.asRect
 import com.getbouncer.scan.ui.util.dpToPixels
-import com.getbouncer.scan.ui.util.fadeIn
-import com.getbouncer.scan.ui.util.fadeOut
 import com.getbouncer.scan.ui.util.getColorByRes
 import com.getbouncer.scan.ui.util.getDrawableByRes
 import com.getbouncer.scan.ui.util.getFloatResource
@@ -28,6 +26,7 @@ import com.getbouncer.scan.ui.util.hide
 import com.getbouncer.scan.ui.util.setDrawable
 import com.getbouncer.scan.ui.util.setTextSizeByRes
 import com.getbouncer.scan.ui.util.setVisible
+import com.getbouncer.scan.ui.util.show
 import com.getbouncer.scan.ui.util.startAnimation
 import kotlinx.coroutines.flow.Flow
 
@@ -589,20 +588,20 @@ abstract class SimpleScanActivity : ScanActivity() {
                 viewFinderWindowView.setBackgroundResource(R.drawable.bouncer_card_background_found)
                 viewFinderBorderView.startAnimation(R.drawable.bouncer_card_border_found)
                 instructionsTextView.setText(R.string.bouncer_card_scan_instructions)
-                instructionsTextView.fadeIn()
+                instructionsTextView.show()
             }
             is ScanState.FoundLong -> {
                 viewFinderBackgroundView.setBackgroundColor(getColorByRes(R.color.bouncerFoundBackground))
                 viewFinderWindowView.setBackgroundResource(R.drawable.bouncer_card_background_found)
                 viewFinderBorderView.startAnimation(R.drawable.bouncer_card_border_found_long)
                 instructionsTextView.setText(R.string.bouncer_card_scan_instructions)
-                instructionsTextView.fadeIn()
+                instructionsTextView.show()
             }
             is ScanState.Correct -> {
                 viewFinderBackgroundView.setBackgroundColor(getColorByRes(R.color.bouncerCorrectBackground))
                 viewFinderWindowView.setBackgroundResource(R.drawable.bouncer_card_background_correct)
                 viewFinderBorderView.startAnimation(R.drawable.bouncer_card_border_correct)
-                instructionsTextView.fadeOut()
+                instructionsTextView.hide()
             }
             is ScanState.Wrong -> {
                 viewFinderBackgroundView.setBackgroundColor(getColorByRes(R.color.bouncerWrongBackground))

--- a/scan-ui/src/main/java/com/getbouncer/scan/ui/util/ViewExtensions.kt
+++ b/scan-ui/src/main/java/com/getbouncer/scan/ui/util/ViewExtensions.kt
@@ -5,11 +5,8 @@ import android.content.res.Resources.NotFoundException
 import android.graphics.PointF
 import android.graphics.Rect
 import android.graphics.drawable.Animatable
-import android.os.Handler
-import android.os.Looper
 import android.util.TypedValue
 import android.view.View
-import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.ColorInt
@@ -17,8 +14,6 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
-import com.getbouncer.scan.framework.time.Duration
-import com.getbouncer.scan.ui.R
 import kotlin.math.roundToInt
 
 /**

--- a/scan-ui/src/main/java/com/getbouncer/scan/ui/util/ViewExtensions.kt
+++ b/scan-ui/src/main/java/com/getbouncer/scan/ui/util/ViewExtensions.kt
@@ -44,35 +44,6 @@ fun View.show() = setVisible(true)
 fun View.hide() = setVisible(false)
 
 /**
- * Fade in a view.
- */
-fun View.fadeIn(duration: Duration? = null) {
-    if (isVisible()) return
-
-    val animation = AnimationUtils.loadAnimation(this.context, R.anim.bouncer_fade_in)
-    visibility = View.INVISIBLE
-    if (duration != null) {
-        animation.duration = duration.inMilliseconds.toLong()
-    }
-    startAnimation(animation)
-    show()
-}
-
-/**
- * Fade out a view.
- */
-fun View.fadeOut(duration: Duration? = null) {
-    if (!isVisible()) return
-
-    val animation = AnimationUtils.loadAnimation(this.context, R.anim.bouncer_fade_out)
-    if (duration != null) {
-        animation.duration = duration.inMilliseconds.toLong()
-    }
-    startAnimation(animation)
-    Handler(Looper.getMainLooper()).postDelayed({ hide() }, duration?.inMilliseconds?.toLong() ?: 400)
-}
-
-/**
  * Get a [ColorInt] from a [ColorRes].
  */
 @ColorInt

--- a/scan-ui/src/main/res/anim/bouncer_fade_in.xml
+++ b/scan-ui/src/main/res/anim/bouncer_fade_in.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:interpolator="@android:anim/linear_interpolator">
-    <alpha
-        android:duration="400"
-        android:fromAlpha="0.0"
-        android:toAlpha="1.0" />
-</set>

--- a/scan-ui/src/main/res/anim/bouncer_fade_out.xml
+++ b/scan-ui/src/main/res/anim/bouncer_fade_out.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:interpolator="@android:anim/linear_interpolator">
-    <alpha
-        android:duration="400"
-        android:fromAlpha="1.0"
-        android:toAlpha="0.0" />
-</set>


### PR DESCRIPTION
When using `shrinkResources = true` in an enclosing app, the animation resources cannot be found. Since these animations don't display well anyway due to heavy GPU usage, just remove them.